### PR TITLE
docs: add in details on gisaid header format for pulling gisaid data of flu…

### DIFF
--- a/bin/aux/pulling-sequences/gisaid_data_pull_fluA.R
+++ b/bin/aux/pulling-sequences/gisaid_data_pull_fluA.R
@@ -13,6 +13,9 @@
 ## original, complete (all 8 segments sequenced) sequences were selected 
 ## sequence files were then concatenated into one .fasta 
 ## metadata files are merged together in this R script. 
+## Download Sequences (DNA) as FASTA using the following header scheme: 
+## Isolate ID | DNA Accession no. | Isolate name | Segment | Segment number
+##############################################################
 ##############################################################
 library(tidyverse)
 library(ape)

--- a/bin/aux/pulling-sequences/gisaid_data_pull_fluB.R
+++ b/bin/aux/pulling-sequences/gisaid_data_pull_fluB.R
@@ -11,6 +11,9 @@
 ## based on submission dates. Submission dates for each .fasta time period
 ## have been written into the names of the fasta files. 
 ## original, complete (all 8 segments sequenced) sequences were selected 
+## Download Sequences (DNA) as FASTA using the following header scheme: 
+## Isolate ID | DNA Accession no. | Isolate name | Segment | Segment number
+##############################################################
 ##############################################################
 library(ape)
 library(tidyverse)


### PR DESCRIPTION
I made some additional documentation comments on the flu A and B GISAID data pulls so I don't forget. Changes were made to two files in bin/aux/pulling-sequences on details related to the fasta header format. For reference the fasta header format used previously when downloading the flu A and flu B data was as follows: 

`Isolate ID | DNA Accession no. | Isolate name | Segment | Segment number` 

<!--
# nf-core/refmaker pull request

Many thanks for contributing to nf-core/refmaker!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/refmaker/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/refmaker/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/refmaker _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
